### PR TITLE
fix(rooms): mount extranetRooms router under /extranet/property/rooms

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-// src/server.ts
+﻿// src/server.ts
 import express from "express";
 import cors from "cors";
 import path from "path";
@@ -65,7 +65,7 @@ await tryMount("./routes/sessionHttp.js", "/");
 await tryMount("./routes/sessionHttp.js", "/extranet");
 
 // features
-await tryMount("./routes/extranetRooms.js", "/extranet");
+await tryMount("./routes/extranetRooms.js", "/extranet/property/rooms");
 await tryMount("./routes/extranetPms.js", "/extranet/pms");
 await tryMount("./routes/property.js", "/extranet/property");
 await tryMount("./routes/propertyPhotos.js", "/extranet/property/photos");
@@ -93,3 +93,4 @@ if (process.env.NODE_ENV !== "test") {
 }
 
 export default app;
+


### PR DESCRIPTION
This PR fixes the mounting path for the extranetRooms router.
- Previously mounted at `/extranet`, which made the live route `/extranet/rooms` unreachable by the frontend.
- Now mounted at `/extranet/property/rooms` to align with the UI calls and route comments in `extranetRooms.js`.

Safe change: only affects the router mount point, no schema or model changes.
